### PR TITLE
Added missing fabric/crashlytics files to .gitignore

### DIFF
--- a/data/custom/Crashlytics.gitignore
+++ b/data/custom/Crashlytics.gitignore
@@ -1,3 +1,5 @@
 #Crashlytics
 crashlytics-build.properties
 com_crashlytics_export_strings.xml
+crashlytics.properties
+fabric.properties


### PR DESCRIPTION
The files crashlytics.properties and fabric.properties contains API Secret used to validate application with crashlytics/fabric API. You should not commit these files to public repository.
